### PR TITLE
SHA1 Mismatch in sqitch_dependencies.rb

### DIFF
--- a/Formula/sqitch_dependencies.rb
+++ b/Formula/sqitch_dependencies.rb
@@ -3,7 +3,7 @@ require 'formula'
 class SqitchDependencies < Formula
   version    '0.980'
   url        "http://api.metacpan.org/source/DWHEELER/App-Sqitch-#{stable.version}/META.json", :using => :nounzip
-  sha1       '23f458280251fb7117af478d2ffa19cb73daaeea'
+  sha1       '6ea23d07226ae30eda4608577aadaaae0c40d903'
   homepage   'http://sqitch.org/'
   depends_on 'cpanminus'
   conflicts_with 'sqitch_maint_depends',

--- a/Formula/sqitch_maint_depends.rb
+++ b/Formula/sqitch_maint_depends.rb
@@ -3,7 +3,7 @@ require 'formula'
 class SqitchMaintDepends < Formula
   version    '0.980'
   url        "http://api.metacpan.org/source/DWHEELER/App-Sqitch-#{stable.version}/META.json", :using => :nounzip
-  sha1       '23f458280251fb7117af478d2ffa19cb73daaeea'
+  sha1       '6ea23d07226ae30eda4608577aadaaae0c40d903'
   homepage   'http://sqitch.org/'
   depends_on 'cpanminus'
   conflicts_with 'sqitch_dependencies',


### PR DESCRIPTION
Hi, I get this error running `brew install sqitch_mysql`

```
Error: SHA1 mismatch
Expected: 23f458280251fb7117af478d2ffa19cb73daaeea
Actual: 6ea23d07226ae30eda4608577aadaaae0c40d903
```
