### PR TITLE
Update Flags in README to Match Respective DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ installing it.
 ### `--with-sqlite-support`
 
     brew install sqitch --with-sqlite-support
-    brew install sqitch --with-postgres-support --without-sqlite
+    brew install sqitch --with-sqlite-support --without-sqlite
 
 Support for managing [SQLite](https://sqlite.org/) databases. This feature
 optionally depends on the Homebrew SQLite build for the use of the `sqlite3`
@@ -45,7 +45,7 @@ installing it.
 ### `--with-mysql-support`
 
     brew install sqitch --with-mysql-support
-    brew install sqitch --with-postgres-support --without-mysql
+    brew install sqitch --with-mysql-support --without-mysql
 
 Support for managing [MySQL](https://www.mysql.com) databases. This feature
 optionally depends on the Homebrew MySQL server, both to build the necessary


### PR DESCRIPTION
I was reading through the README and was a bit confused about some of the flags.

Correct me if I'm wrong, but I think these updates map to what the paragraphs are talking about (ie. you can install w/ SQLite / MySQL but opt out of installing the underlying Homebrew dependency). Was a bit confused how installing with PostgreSQL support would install w/ SQLite / MySQL.

If you combine the `--with-<db>-support` and `--without-<db>`, would they do anything other than cancel each other and install Sqitch w/o a db dependency?

Anyways, thanks for maintaining Sqitch!