### PR TITLE
master/sqitch.rb: fix Homebrew death on all operations

### DIFF
--- a/Formula/sqitch.rb
+++ b/Formula/sqitch.rb
@@ -7,7 +7,7 @@ class Sqitch < Formula
   opoo "requiring an update to the default homebrew tap."
   opoo ""
 
-  odie """To upgrade sqitch, retap it with:
+  opoo """To upgrade sqitch, retap it with:
     brew untap sqitchers/sqitch
     brew tap sqitchers/sqitch
     brew upgrade sqitch"""


### PR DESCRIPTION
Homebrew will load all formulae during most operations, so a user still on the `master` branch can't follow your upgrade instructions, because `odie` kills `brew` prematurely.

Addresses https://discourse.brew.sh/t/stuck-with-sqitch/8614