### PR TITLE
Removed deprecated bottle :unneeded

### DIFF
--- a/Formula/sqitch.rb
+++ b/Formula/sqitch.rb
@@ -13,7 +13,6 @@ class Sqitch < Formula
   head       'https://github.com/sqitchers/sqitch.git'
   depends_on 'perl'
   depends_on 'cpanminus' => :build
-  bottle     :unneeded
 
   option 'with-postgres-support',  "Support for managing PostgreSQL databases"
   option 'with-sqlite-support',    "Support for managing SQLite databases"


### PR DESCRIPTION
Homebrew issues following warning:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the sqitchers/sqitch tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/sqitchers/homebrew-sqitch/Formula/sqitch.rb:16
```

