### PR TITLE
Remove all references to `--without-*` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,23 @@ get it installed so you can get to work.
 
 First, use this command to set up the Sqitch Homebrew tap:
 
-    brew tap sqitchers/sqitch
+``` sh
+brew tap sqitchers/sqitch
+```
 
 Now you can install Sqitch with your choice of database support:
 
-    brew install sqitch --with-postgres-support --with-sqlite-support
+``` sh
+brew install sqitch --with-postgres-support --with-sqlite-support
+```
 
 If you see an error about missing headers on Mojave, like
 `fatal error: 'EXTERN.h' file not found`, install the headers like so and try
 again:
 
-    sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
+``` sh
+sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
+```
 
 Supported Database Engines
 --------------------------
@@ -27,8 +33,9 @@ Mix and match support as you prefer via the following options:
 
 ### `--with-postgres-support`
 
-    brew install sqitch --with-postgres-support
-    brew install sqitch --with-postgres-support --without-postgresql
+``` sh
+brew install sqitch --with-postgres-support
+```
 
 Support for managing [PostgreSQL](https://www.postgresql.org),
 [CockroachDB](https://www.cockroachlabs.com/product/), and
@@ -38,9 +45,8 @@ necessary database driver at build time, and to use `psql` client to manage
 databases at runtime. It does not install the Homebrew PostgreSQL server.
 
 If you have your own PostgreSQL client library install and don't need the
-Homebrew instance, pass `--without-postgresql` to prevent Homebrew from
-installing it --- although then you might need to tell the installer where to
-find things. To quote from the [DBD::Pg README](https://github.com/bucardo/dbdpg#readme):
+Homebrew instance, you might need to tell the installer where to find things.
+To quote from the [DBD::Pg README](https://github.com/bucardo/dbdpg#readme):
 
 > By default Makefile.PL uses App::Info to find the location of the
 > PostgreSQL library and include directories. However, if you want to
@@ -54,40 +60,44 @@ find things. To quote from the [DBD::Pg README](https://github.com/bucardo/dbdpg
 If, for example, you use [pgenv](https://github.com/theory/pgenv) to
 install PostgreSQL on your system, you'd need to export something like:
 
+``` sh
 export POSTGRES_LIB="$HOME/.pgenv/pgsql/lib -lssl -lcrypto"
 export POSTGRES_INCLUDE="$HOME/.pgenv/pgsql/include"
+```
 
 Then build with `--with-std-env` to ensure that Homebrew will use the
 environment variables:
 
-    brew install sqitch --with-std-env --with-postgres-support --without-postgresql
+``` sh
+brew install sqitch --with-std-env --with-postgres-support
+```
 
 ### `--with-sqlite-support`
 
-    brew install sqitch --with-sqlite-support
-    brew install sqitch --with-sqlite-support --without-sqlite
+``` sh
+brew install sqitch --with-sqlite-support
+```
 
 Support for managing [SQLite](https://sqlite.org/) databases. This feature
 optionally depends on the Homebrew SQLite build for the use of the `sqlite3`
-client at runtime. If you have your own install or just want to rely on the
-macOS system-provided SQLite, pass `--without-sqlite` to prevent Homebrew from
-installing it.
+client at runtime.
 
 ### `--with-mysql-support`
 
-    brew install sqitch --with-mysql-support
-    brew install sqitch --with-mysql-support --without-mysql
+``` sh
+brew install sqitch --with-mysql-support
+```
 
 Support for managing [MySQL](https://www.mysql.com) databases. This feature
 optionally depends on the Homebrew `mysql-client` formula, both to build the
-necessary database driver at build time, and to use the `mysql` client to manage
-databases at runtime. It does not install the Homebrew MySQL server. If you have
-your own MySQL client install and don't need the Homebrew instance, pass
-`--without-mysql` to prevent Homebrew from installing it.
+necessary database driver at build time, and to use the `mysql` client to
+manage databases at runtime. It does not install the Homebrew MySQL server.
 
 ### `--with-firebird-support`
 
-    brew install sqitch --with-firebird-support
+``` sh
+brew install sqitch --with-firebird-support
+```
 
 Support for managing [Firebird](https://www.firebirdsql.org) databases. This
 feature depends on the presence of a Firebird database installation, both to
@@ -100,8 +110,10 @@ found, the build will fail.
 
 ### `--with-oracle-support`
 
-    export HOMEBREW_ORACLE_HOME=/oracle/instantclient_12_2
-    brew install sqitch --with-oracle-support
+``` sh
+export HOMEBREW_ORACLE_HOME=/oracle/instantclient_12_2
+brew install sqitch --with-oracle-support
+```
 
 Support for managing [Oracle](https://www.oracle.com/database/) databases. This
 feature depends on the presence of the
@@ -122,13 +134,14 @@ complete the build with Oracle support. To use Sqitch with Oracle, you will
 need to set the `$ORACLE_HOME` and `$DYLD_LIBRARY_PATH` variables to point to
 the Instant Client, something like:
 
-    export ORACLE_HOME=/usr/local/instantclient_12_2
-    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$ORACLE_HOME
+``` sh
+export ORACLE_HOME=/usr/local/instantclient_12_2
+export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$ORACLE_HOME
+```
 
 ### `--with-vertica-support`
 
     brew install sqitch --with-vertica-support
-    brew install sqitch --with-vertica-support --without-libiodbc
 
 Support for managing [Vertica](https://www.vertica.com) databases. This
 feature depends on the presence of the Vertica ODBC driver and the `vsql`
@@ -138,14 +151,13 @@ install the ODBC and `vsql` packages for macOS prior to using Sqitch to
 manage Vertica databases.
 
 Furthermore, the Sqitch Vertica build optionally requires the Homebrew
-`libiodbc` package to build the ODBC driver. If you have your own build of iODBC
-or unixODBC that you'd rather use, pass `--without-libiodbc` to prevent Homebrew
-from installing it.
+`libiodbc` package to build the ODBC driver.
 
 ### `--with-exasol-support`
 
-    brew install sqitch --with-exasol-support
-    brew install sqitch --with-exasol-support --without-libiodbc
+``` sh
+brew install sqitch --with-exasol-support
+```
 
 Support for managing [Exasol](https://www.exasol.com) databases. This feature
 depends on the presence of the Exasol ODBC driver and the `EXAplus` client in
@@ -154,35 +166,33 @@ order to manage Exasol databases. You will need to
 and EXAplus packages for macOS prior to using Sqitch to manage Exasol databases.
 
 Furthermore, the Sqitch Exasol build optionally requires the Homebrew `libiodbc`
-package to build the ODBC driver. f you have your own build of iODBC or unixODBC
-that you'd rather use, pass `--without-libiodbc` to prevent Homebrew from
-installing it.
+package to build the ODBC driver.
 
 ### `--with-snowflake-support`
 
-    brew install sqitch --with-snowflake-support
-    brew install sqitch --with-snowflake-support --without-libiodbc
+``` sh
+brew install sqitch --with-snowflake-support
+```
 
 Support for managing [Snowflake](https://www.snowflake.com) databases. This
 feature depends on the presence of the Snowflake ODBC driver and the `snowsql`
 client in order to manage Snowflake databases. You will need to download,
 install and configure the
-[ODBC driver](https://docs.snowflake.net/manuals/user-guide/odbc-download.html)
-and
+[ODBC driver](https://docs.snowflake.net/manuals/user-guide/odbc-download.html) and
 [SnowSQL](https://docs.snowflake.net/manuals/user-guide/snowsql-install-config.html)
 client prior to using Sqitch to manage Snowflake databases.
 
 Furthermore, the Sqitch Snowflake build optionally requires the Homebrew
-`libiodbc` package to build the ODBC driver. f you have your own build of iODBC
-or unixODBC that you'd rather use, pass `--without-libiodbc` to prevent Homebrew
-from installing it.
+`libiodbc` package to build the ODBC driver.
 
 Other Options
 -------------
 
 ### `--with-std-env`
 
-  brew install sqitch --with-std-env
+``` sh
+brew install sqitch --with-std-env
+```
 
 Prefer versions of dependencies found in the path, even if they're not installed
 by Homebrew. Essential if you want to use a library or database client that is
@@ -190,7 +200,9 @@ not installed by Homebrew and does not come with the system.
 
 ### `--HEAD`
 
-    brew install sqitch --HEAD
+``` sh
+brew install sqitch --HEAD
+```
 
 Just want the latest from Git? Use the `--HEAD` option to clone Sqitch, install
 configure-time dependencies in a temporary directory, and build Sqitch from the
@@ -198,14 +210,18 @@ main branch.
 
 ### `--devel`
 
-    brew install sqitch --devel
+``` sh
+brew install sqitch --devel
+```
 
 Sometimes a pre-release version of Sqitch might be available for installation.
 If so, the `--devel` option will build and install it.
 
 ### `--verbose`
 
-    brew install sqitch --verbose
+``` sh
+brew install sqitch --verbose
+```
 
 Turn on verbosity. Useful to get additional information in the event of
 installation issues.


### PR DESCRIPTION
According to [this discussion], support for them was removed back in
2018. No one complained here until January 2024, so the assumption is that they were not much used.

More to the point, as of 8167e40, the Postgres and MySQL server dependencies were replaced with client-only dependencies, reducing the need to prevent their installation. People still might want to build with their own `libpq` or `mysql` client libraries, but they just need to be sure they're found in their search paths (including library and include) ahead of the Homebrew paths. In any event, since 8167e40 there have been no more servers fired up (one hopes).

If it turns out people really do need a way to prevent the driver and client dependencies from being installed, we can add our own `--without` options. But as of right now, it doesn't seem necessary.

Resolves #62.

While at it, switch to fenced code blocks in the README.

  [this discussion]: https://github.com/orgs/Homebrew/discussions/5428